### PR TITLE
Copy primary and foreign keys when cloning databases

### DIFF
--- a/ConvertDB/frmCopyDB.cs
+++ b/ConvertDB/frmCopyDB.cs
@@ -88,6 +88,9 @@ namespace ConvertDB
 
                                 // Step 2: Copy data
                                 Helpers.CopyData(sourceConnectionString, destinationConnectionString);
+
+                                // Step 3: Copy foreign key constraints
+                                Helpers.CopyForeignKeys(sourceConnectionString, destinationConnectionString);
                                 DialogResult = DialogResult.OK;
                             }
                             catch (Exception ex)

--- a/Utilities/Tools/Tools.cs
+++ b/Utilities/Tools/Tools.cs
@@ -189,10 +189,16 @@ namespace Utilities
 
                 foreach (DataRow table in tables.Rows)
                 {
-                    string tableName = table["TABLE_NAME"].ToString();
+                    if (!string.Equals(table["TABLE_TYPE"].ToString(), "BASE TABLE", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
 
-                    // Get the schema for the current table
-                    string createTableQuery = GetCreateTableQuery(sourceConn, tableName);
+                    string tableName = table["TABLE_NAME"].ToString();
+                    string tableSchema = table["TABLE_SCHEMA"].ToString();
+
+                    // Get the schema for the current table including keys
+                    string createTableQuery = GetCreateTableQuery(sourceConn, tableSchema, tableName);
 
                     // Execute the create table query in the target database
                     using (SqlCommand cmd = new SqlCommand(createTableQuery, targetConn))
@@ -200,31 +206,36 @@ namespace Utilities
                         cmd.ExecuteNonQuery();
                     }
                 }
+
             }
         }
 
-        public static string GetCreateTableQuery(SqlConnection connection, string tableName)
+        public static string GetCreateTableQuery(SqlConnection connection, string tableSchema, string tableName)
         {
             string query = @"
-                            SELECT 
-                                COLUMN_NAME, 
-                                DATA_TYPE, 
-                                CHARACTER_MAXIMUM_LENGTH, 
+                            SELECT
+                                COLUMN_NAME,
+                                DATA_TYPE,
+                                CHARACTER_MAXIMUM_LENGTH,
+                                NUMERIC_PRECISION,
+                                NUMERIC_SCALE,
                                 IS_NULLABLE
                             FROM INFORMATION_SCHEMA.COLUMNS
-                            WHERE TABLE_NAME = @TableName";
+                            WHERE TABLE_NAME = @TableName AND TABLE_SCHEMA = @TableSchema";
             DataTable columns = new DataTable();
 
             using (SqlCommand cmd = new SqlCommand(query, connection))
             {
                 cmd.Parameters.AddWithValue("@TableName", tableName);
+                cmd.Parameters.AddWithValue("@TableSchema", tableSchema);
                 using (SqlDataAdapter adapter = new SqlDataAdapter(cmd))
                 {
                     adapter.Fill(columns);
                 }
             }
 
-            string createTableQuery = $"CREATE TABLE {tableName} (";
+            string fullTableName = $"[{tableSchema}].[{tableName}]";
+            string createTableQuery = $"CREATE TABLE {fullTableName} (";
             foreach (DataRow column in columns.Rows)
             {
                 string columnName = column["COLUMN_NAME"].ToString();
@@ -233,9 +244,15 @@ namespace Utilities
                 int characterMaxLength = column["CHARACTER_MAXIMUM_LENGTH"] != DBNull.Value
                     ? Convert.ToInt32(column["CHARACTER_MAXIMUM_LENGTH"])
                     : -1;
+                int numericPrecision = column["NUMERIC_PRECISION"] != DBNull.Value
+                    ? Convert.ToInt32(column["NUMERIC_PRECISION"])
+                    : -1;
+                int numericScale = column["NUMERIC_SCALE"] != DBNull.Value
+                    ? Convert.ToInt32(column["NUMERIC_SCALE"])
+                    : -1;
 
                 // Append the column definition to the CREATE TABLE query
-                createTableQuery += $"{columnName} {dataType}";
+                createTableQuery += $"[{columnName}] {dataType}";
 
                 // Add size for string types (e.g., NVARCHAR(150))
                 if (characterMaxLength > 0 && (dataType.ToUpper() == "NVARCHAR" || dataType.ToUpper() == "VARCHAR"))
@@ -246,13 +263,175 @@ namespace Utilities
                 {
                     createTableQuery += "(MAX)"; // Handle MAX sizes
                 }
+                else if (numericPrecision > 0 && numericScale >= 0 &&
+                         (dataType.ToUpper() == "DECIMAL" || dataType.ToUpper() == "NUMERIC"))
+                {
+                    createTableQuery += $"({numericPrecision}, {numericScale})";
+                }
 
                 // Add NOT NULL if applicable
                 createTableQuery += $" {(isNullable == "NO" ? "NOT NULL" : "")}, ";
             }
+            string primaryKeyDefinition = GetPrimaryKeyDefinition(connection, tableSchema, tableName);
+            if (!string.IsNullOrEmpty(primaryKeyDefinition))
+            {
+                createTableQuery += primaryKeyDefinition + ", ";
+            }
             createTableQuery = createTableQuery.TrimEnd(',', ' ') + ")";
 
             return createTableQuery;
+        }
+        private static string GetPrimaryKeyDefinition(SqlConnection connection, string tableSchema, string tableName)
+        {
+            string pkQuery = @"
+                SELECT
+                    KU.CONSTRAINT_NAME,
+                    KU.COLUMN_NAME,
+                    KU.ORDINAL_POSITION
+                FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS TC
+                INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KU
+                    ON TC.CONSTRAINT_NAME = KU.CONSTRAINT_NAME
+                    AND TC.TABLE_NAME = KU.TABLE_NAME
+                    AND TC.TABLE_SCHEMA = KU.TABLE_SCHEMA
+                WHERE TC.TABLE_NAME = @TableName
+                    AND TC.TABLE_SCHEMA = @TableSchema
+                    AND TC.CONSTRAINT_TYPE = 'PRIMARY KEY'
+                ORDER BY KU.ORDINAL_POSITION";
+
+            DataTable primaryKeyInfo = new DataTable();
+            using (SqlCommand cmd = new SqlCommand(pkQuery, connection))
+            {
+                cmd.Parameters.AddWithValue("@TableName", tableName);
+                cmd.Parameters.AddWithValue("@TableSchema", tableSchema);
+                using (SqlDataAdapter adapter = new SqlDataAdapter(cmd))
+                {
+                    adapter.Fill(primaryKeyInfo);
+                }
+            }
+
+            if (primaryKeyInfo.Rows.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            string constraintName = primaryKeyInfo.Rows[0]["CONSTRAINT_NAME"].ToString();
+            List<string> columns = new List<string>();
+            foreach (DataRow row in primaryKeyInfo.Rows)
+            {
+                columns.Add($"[{row["COLUMN_NAME"].ToString()}]");
+            }
+
+            return $"CONSTRAINT [{constraintName}] PRIMARY KEY ({string.Join(", ", columns)})";
+        }
+
+        private class ForeignKeyDefinition
+        {
+            public string Name { get; set; }
+            public string ParentSchema { get; set; }
+            public string ParentTable { get; set; }
+            public string ReferencedSchema { get; set; }
+            public string ReferencedTable { get; set; }
+            public string DeleteAction { get; set; }
+            public string UpdateAction { get; set; }
+            public List<KeyValuePair<string, string>> Columns { get; } = new List<KeyValuePair<string, string>>();
+        }
+
+        public static void CopyForeignKeys(string sourceConnectionString, string targetConnectionString)
+        {
+            using (SqlConnection sourceConnection = new SqlConnection(sourceConnectionString))
+            using (SqlConnection targetConnection = new SqlConnection(targetConnectionString))
+            {
+                sourceConnection.Open();
+                targetConnection.Open();
+
+                ApplyForeignKeys(sourceConnection, targetConnection);
+            }
+        }
+
+        private static void ApplyForeignKeys(SqlConnection sourceConnection, SqlConnection targetConnection)
+        {
+            const string foreignKeyQuery = @"
+                SELECT
+                    fk.name AS FKName,
+                    schParent.name AS ParentSchema,
+                    tp.name AS ParentTable,
+                    schRef.name AS ReferencedSchema,
+                    tr.name AS ReferencedTable,
+                    cp.name AS ParentColumn,
+                    cr.name AS ReferencedColumn,
+                    fkc.constraint_column_id,
+                    fk.delete_referential_action_desc,
+                    fk.update_referential_action_desc
+                FROM sys.foreign_keys AS fk
+                INNER JOIN sys.foreign_key_columns AS fkc ON fk.object_id = fkc.constraint_object_id
+                INNER JOIN sys.tables AS tp ON fk.parent_object_id = tp.object_id
+                INNER JOIN sys.schemas AS schParent ON tp.schema_id = schParent.schema_id
+                INNER JOIN sys.columns AS cp ON fkc.parent_object_id = cp.object_id AND fkc.parent_column_id = cp.column_id
+                INNER JOIN sys.tables AS tr ON fk.referenced_object_id = tr.object_id
+                INNER JOIN sys.schemas AS schRef ON tr.schema_id = schRef.schema_id
+                INNER JOIN sys.columns AS cr ON fkc.referenced_object_id = cr.object_id AND fkc.referenced_column_id = cr.column_id
+                ORDER BY fk.name, fkc.constraint_column_id";
+
+            Dictionary<string, ForeignKeyDefinition> foreignKeys = new Dictionary<string, ForeignKeyDefinition>(StringComparer.OrdinalIgnoreCase);
+
+            using (SqlCommand cmd = new SqlCommand(foreignKeyQuery, sourceConnection))
+            using (SqlDataReader reader = cmd.ExecuteReader())
+            {
+                while (reader.Read())
+                {
+                    string fkName = reader.GetString(0);
+                    if (!foreignKeys.TryGetValue(fkName, out ForeignKeyDefinition definition))
+                    {
+                        definition = new ForeignKeyDefinition
+                        {
+                            Name = fkName,
+                            ParentSchema = reader.GetString(1),
+                            ParentTable = reader.GetString(2),
+                            ReferencedSchema = reader.GetString(3),
+                            ReferencedTable = reader.GetString(4),
+                            DeleteAction = reader.GetString(8),
+                            UpdateAction = reader.GetString(9)
+                        };
+                        foreignKeys.Add(fkName, definition);
+                    }
+
+                    string parentColumn = reader.GetString(5);
+                    string referencedColumn = reader.GetString(6);
+                    definition.Columns.Add(new KeyValuePair<string, string>(parentColumn, referencedColumn));
+                }
+            }
+
+            foreach (ForeignKeyDefinition foreignKey in foreignKeys.Values)
+            {
+                string parentTableFullName = $"[{foreignKey.ParentSchema}].[{foreignKey.ParentTable}]";
+                string referencedTableFullName = $"[{foreignKey.ReferencedSchema}].[{foreignKey.ReferencedTable}]";
+                string parentColumns = string.Join(", ", foreignKey.Columns.Select(column => $"[{column.Key}]"));
+                string referencedColumns = string.Join(", ", foreignKey.Columns.Select(column => $"[{column.Value}]"));
+
+                StringBuilder fkBuilder = new StringBuilder();
+                fkBuilder.Append($"ALTER TABLE {parentTableFullName} WITH NOCHECK ADD CONSTRAINT [{foreignKey.Name}] FOREIGN KEY ({parentColumns}) REFERENCES {referencedTableFullName} ({referencedColumns})");
+
+                if (!string.Equals(foreignKey.DeleteAction, "NO_ACTION", StringComparison.OrdinalIgnoreCase))
+                {
+                    fkBuilder.Append($" ON DELETE {foreignKey.DeleteAction}");
+                }
+
+                if (!string.Equals(foreignKey.UpdateAction, "NO_ACTION", StringComparison.OrdinalIgnoreCase))
+                {
+                    fkBuilder.Append($" ON UPDATE {foreignKey.UpdateAction}");
+                }
+
+                using (SqlCommand addConstraintCmd = new SqlCommand(fkBuilder.ToString(), targetConnection))
+                {
+                    addConstraintCmd.ExecuteNonQuery();
+                }
+
+                string checkConstraintQuery = $"ALTER TABLE {parentTableFullName} CHECK CONSTRAINT [{foreignKey.Name}]";
+                using (SqlCommand checkConstraintCmd = new SqlCommand(checkConstraintQuery, targetConnection))
+                {
+                    checkConstraintCmd.ExecuteNonQuery();
+                }
+            }
         }
         public static void CopyData(string sourceConnectionString, string targetConnectionString)
         {
@@ -267,28 +446,45 @@ namespace Utilities
 
                 foreach (DataRow table in tables.Rows)
                 {
+                    if (!string.Equals(table["TABLE_TYPE"].ToString(), "BASE TABLE", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
                     string tableName = table["TABLE_NAME"].ToString();
+                    string tableSchema = table["TABLE_SCHEMA"].ToString();
+                    string fullTableName = $"[{tableSchema}].[{tableName}]";
 
                     // Read data from the source table
-                    string selectQuery = $"SELECT * FROM {tableName}";
+                    string selectQuery = $"SELECT * FROM {fullTableName}";
                     using (SqlCommand selectCmd = new SqlCommand(selectQuery, sourceConn))
                     using (SqlDataReader reader = selectCmd.ExecuteReader())
                     {
                         // Get the column sizes for the target table
-                        DataTable columnSizes = GetColumnSizes(targetConn, tableName);
+                        DataTable columnSizes = GetColumnSizes(targetConn, tableSchema, tableName);
 
                         // Insert data into the target table
                         while (reader.Read())
                         {
-                            string insertQuery = $"INSERT INTO {tableName} VALUES (";
+                            string insertQuery = $"INSERT INTO {fullTableName} VALUES (";
                             for (int i = 0; i < reader.FieldCount; i++)
                             {
                                 string columnName = reader.GetName(i);
-                                string columnValue = reader[i].ToString();
+                                object value = reader[i];
+
+                                string columnValue;
+                                if (value == DBNull.Value)
+                                {
+                                    columnValue = "NULL";
+                                }
+                                else
+                                {
+                                    columnValue = value.ToString();
+                                }
 
                                 // Truncate the value if it exceeds the column size
                                 int columnSize = GetColumnSize(columnSizes, columnName);
-                                if (columnSize > 0 && columnValue.Length > columnSize)
+                                if (columnSize > 0 && columnValue != null && columnValue != "NULL" && columnValue.Length > columnSize)
                                 {
                                     columnValue = columnValue.Substring(0, columnSize);
                                 }
@@ -297,16 +493,20 @@ namespace Utilities
                                 bool isUnicode = IsUnicodeColumn(columnSizes, columnName);
 
                                 // Prefix Unicode strings with N''
-                                if (isUnicode)
+                                if (columnValue == "NULL")
+                                {
+                                    insertQuery += "NULL, ";
+                                }
+                                else if (isUnicode)
                                 {
                                     columnValue = $"N'{columnValue.Replace("'", "''")}'";
+                                    insertQuery += $"{columnValue}, ";
                                 }
                                 else
                                 {
                                     columnValue = $"'{columnValue.Replace("'", "''")}'";
+                                    insertQuery += $"{columnValue}, ";
                                 }
-
-                                insertQuery += $"{columnValue}, ";
                             }
                             insertQuery = insertQuery.TrimEnd(',', ' ') + ")";
 
@@ -333,17 +533,18 @@ namespace Utilities
             return false;
         }
 
-        public static DataTable GetColumnSizes(SqlConnection connection, string tableName)
+        public static DataTable GetColumnSizes(SqlConnection connection, string tableSchema, string tableName)
         {
             string query = @"
         SELECT COLUMN_NAME, CHARACTER_MAXIMUM_LENGTH, DATA_TYPE
         FROM INFORMATION_SCHEMA.COLUMNS
-        WHERE TABLE_NAME = @TableName";
+        WHERE TABLE_NAME = @TableName AND TABLE_SCHEMA = @TableSchema";
             DataTable columnSizes = new DataTable();
 
             using (SqlCommand cmd = new SqlCommand(query, connection))
             {
                 cmd.Parameters.AddWithValue("@TableName", tableName);
+                cmd.Parameters.AddWithValue("@TableSchema", tableSchema);
                 using (SqlDataAdapter adapter = new SqlDataAdapter(cmd))
                 {
                     adapter.Fill(columnSizes);


### PR DESCRIPTION
## Summary
- include primary key definitions when creating tables during schema copy
- add utilities to recreate foreign key constraints after transferring data
- update the copy workflow to apply foreign keys once data is migrated

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6905c3fce1a483278435ee685f4b218f